### PR TITLE
Updated NotebookCondition struct

### DIFF
--- a/apis/kubeflow/v1/notebook_types.go
+++ b/apis/kubeflow/v1/notebook_types.go
@@ -47,9 +47,14 @@ type NotebookStatus struct {
 type NotebookCondition struct {
 	// Type is the type of the condition. Possible values are Running|Waiting|Terminated
 	Type string `json:"type"`
+	// Status is the status of the condition. Can be True, False, Unknown.
+	Status string `json:"status"`
 	// Last time we probed the condition.
 	// +optional
 	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty"`
+	// Last time the condition transitioned from one status to another.
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 	// (brief) reason the container is in the current state
 	// +optional
 	Reason string `json:"reason,omitempty"`


### PR DESCRIPTION
Updated the NotebookCondition struct to match the definition in https://pkg.go.dev/github.com/kubeflow/kubeflow/components/notebook-controller@v0.0.0-20230529130803-72f3063b1a11/api/v1#NotebookCondition